### PR TITLE
Improve CIN description and colors to be more accurate

### DIFF
--- a/src/features/rap/CinCape.tsx
+++ b/src/features/rap/CinCape.tsx
@@ -42,8 +42,8 @@ const Description = styled.div`
 `;
 
 const cinColorScale = chroma
-  .scale(["white", "white", "yellow", "red"])
-  .domain([0, -20, -50, -90]);
+  .scale(["red", "yellow", "white", "white"])
+  .domain([0, -51, -200, -300]);
 
 const Cin = styled.span<{ cin: number }>`
   ${({ cin }) => outputP3ColorFromLab(cinColorScale(cin).lab())};
@@ -84,13 +84,14 @@ export default function CinCape({ cin, cape }: CinCapeProps) {
               </p>
               <p>
                 CIN values between <Cin cin={0}>0</Cin> and{" "}
-                <Cin cin={-25}>-25</Cin> are classified as weak inhibition.
+                <Cin cin={-50}>-50</Cin> are classified as weak inhibition and
+                mean you have a chance of a very large storm if CAPE is present!
               </p>{" "}
               <p>
-                CIN values between <Cin cin={-25}>-25</Cin> and{" "}
-                <Cin cin={-50}>-50</Cin>, typically qualify as moderate. When
-                you see CIN values of <Cin cin={-100}>-100</Cin>, you have a
-                chance of a very large storm!
+                CIN values between <Cin cin={-51}>-51</Cin> and{" "}
+                <Cin cin={-199}>-199</Cin>, typically qualify as moderate. CIN 
+                values of <Cin cin={-200}>-200</Cin> are classified as strong
+                inhibition which means more stable air with less chance of convection.
               </p>
             </Description>
           )}


### PR DESCRIPTION
Hey, I tried to email this to hello@ppg.report but it bounced. I studied meteorology and noticed the last sentence of the CIN description (and chosen colors) is wrong because when CIN is closer to 0, it is more dangerous to fly. (Zero inhibition means there is nothing stopping air from convecting). 

I've also updated the CIN ranges used for weak, moderate, and strong to reflect what I've seen in scientific papers. 

It's confusing because of the negative values used to describe negative energy, but it's important for pilots to know that CIN values closer to zero are more dangerous and CIN values farther from zero are more stable. This all depends on CAPE as well.

I am NOT a programmer at all and made a GitHub account just for this.